### PR TITLE
Fix puzzle-diff for the exact matching

### DIFF
--- a/src/puzzle-diff.c
+++ b/src/puzzle-diff.c
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
         printf("%g\n", d);
         return 0;
     }
-    if (d >= opts.similarity_threshold) {
+    if (d > opts.similarity_threshold) {
         return 20;
     }
     return 10;


### PR DESCRIPTION
E.g. The following command will return 20 as not similar.
puzzle-diff -e -E 0 pics/pic-a-0.jpg pics/pic-a-0.jpg
But 10 should be returned.
