### PR TITLE
Blending transparent pixels with white background

### DIFF
--- a/src/dvec.c
+++ b/src/dvec.c
@@ -517,6 +517,19 @@ static int puzzle_fill_dvec(PuzzleDvec * const dvec,
     return 0;
 }
 
+static void puzzle_remove_transparency(gdImagePtr gdimage)
+{
+    int background = gdTrueColor(255, 255, 255);
+    
+    int x,y;
+    for (y = 0; (y < gdimage->sy); y++) {
+        for (x = 0; (x < gdimage->sx); x++) {
+            int cpix = gdimage->tpixels[y][x];
+            gdImageSetPixel(gdimage, x, y, gdAlphaBlend(background, cpix) );
+        }
+    }
+}
+
 static gdImagePtr puzzle_create_gdimage_from_file(const char * const file)
 {
     gdImagePtr gdimage = NULL;
@@ -606,6 +619,7 @@ int puzzle_fill_dvec_from_file(PuzzleContext * const context,
     if (gdimage == NULL) {
             return -1;
     }
+    puzzle_remove_transparency(gdimage);
     ret = puzzle_fill_dvec_from_gdimage(context, dvec, gdimage);
     gdImageDestroy(gdimage);
     return ret;
@@ -621,6 +635,7 @@ int puzzle_fill_dvec_from_mem(PuzzleContext * const context,
     if (gdimage == NULL) {
             return -1;
     }
+    puzzle_remove_transparency(gdimage);
     ret = puzzle_fill_dvec_from_gdimage(context, dvec, gdimage);
     gdImageDestroy(gdimage);
     return ret;

--- a/src/dvec.c
+++ b/src/dvec.c
@@ -522,6 +522,8 @@ static void puzzle_remove_transparency(gdImagePtr gdimage)
     int background = gdTrueColor(255, 255, 255);
     int x,y,cpix;
     
+    gdImagePaletteToTrueColor(gdimage);
+    
     for (y = 0; (y < gdImageSY(gdimage)); y++) {
         for (x = 0; (x < gdImageSX(gdimage)); x++) {
             cpix = gdImageGetTrueColorPixel(gdimage, x, y);

--- a/src/dvec.c
+++ b/src/dvec.c
@@ -520,11 +520,11 @@ static int puzzle_fill_dvec(PuzzleDvec * const dvec,
 static void puzzle_remove_transparency(gdImagePtr gdimage)
 {
     int background = gdTrueColor(255, 255, 255);
+    int x,y,cpix;
     
-    int x,y;
-    for (y = 0; (y < gdimage->sy); y++) {
-        for (x = 0; (x < gdimage->sx); x++) {
-            int cpix = gdimage->tpixels[y][x];
+    for (y = 0; (y < gdImageSY(gdimage)); y++) {
+        for (x = 0; (x < gdImageSX(gdimage)); x++) {
+            cpix = gdImageGetTrueColorPixel(gdimage, x, y);
             gdImageSetPixel(gdimage, x, y, gdAlphaBlend(background, cpix) );
         }
     }


### PR DESCRIPTION
This is a fix for issue #9

All transparent pixels are blended with a white background before processing.

I tried to look into a way to use png's `bKGD` chunk for background color (as suggested in the issue), but gdlib2 does not appear to have a way to access this information.
